### PR TITLE
Add initial React Vite skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# codex
-ChatGPTCodex
+# WAT Viewer
+
+This project is a minimal mock implementation of a wafer analysis viewer.
+
+It uses React + Vite with TypeScript. The actual dependencies are not installed in this environment.
+
+Run `npm install` followed by `npm run dev` to start development (requires internet access).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WAT Viewer</title>
+  </head>
+  <body class="bg-gray-900 text-white">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "wat-viewer",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
+    "d3": "^7.9.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.4.0"
+  }
+}

--- a/public/data/WAT_9site_dummy_long_v2.csv
+++ b/public/data/WAT_9site_dummy_long_v2.csv
@@ -1,0 +1,4 @@
+lot,site,coord,item,device,parameter,specHigh,specLow,value
+#1,Site 1,(0,0),Item1,SVT,Idsat,10,5,7
+#1,Site 2,(1,0),Item1,SVT,Idsat,10,5,6
+#1,Site 3,(0,1),Item1,SVT,Idsat,10,5,8

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,16 @@
+import { Routes, Route } from 'react-router-dom';
+import Home from './pages/Home';
+import WaferSelect from './pages/WaferSelect';
+import WaferDetail from './pages/WaferDetail';
+import ChipDetail from './pages/ChipDetail';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/lot/:lotId" element={<WaferSelect />} />
+      <Route path="/lot/:lotId/wafer/:waferId" element={<WaferDetail />} />
+      <Route path="/lot/:lotId/wafer/:waferId/chip/:chipId" element={<ChipDetail />} />
+    </Routes>
+  );
+}

--- a/src/api/comment.ts
+++ b/src/api/comment.ts
@@ -1,0 +1,10 @@
+export async function fetchAiComment(ctx: { lot: string; wafer: string; param: string; device: string; }): Promise<string> {
+  return new Promise(r => setTimeout(() => {
+    const msgs = [
+      'All sites in spec.\nNo action needed.',
+      'Hotspot detected near (3,-4).\nCheck implant uniformity.',
+      'Idsat trending high (+2 %).\nMonitor next lot.'
+    ];
+    r(msgs[Math.floor(Math.random()*msgs.length)]);
+  }, 1200));
+}

--- a/src/components/Heatmap.tsx
+++ b/src/components/Heatmap.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  lot: string;
+  wafer: string;
+  onSelectChip: (chip: string) => void;
+}
+export default function Heatmap({ lot, wafer, onSelectChip }: Props) {
+  const cells = Array.from({ length: 9 }, (_, i) => i + 1);
+  return (
+    <svg width={200} height={200} className="border">
+      {cells.map(c => (
+        <rect key={c} x={(c%3)*60} y={Math.floor(c/3)*60} width={50} height={50} fill="gray" onClick={() => onSelectChip(String(c))} />
+      ))}
+    </svg>
+  );
+}

--- a/src/components/LotCard.tsx
+++ b/src/components/LotCard.tsx
@@ -1,0 +1,11 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function LotCard({ lot }: { lot: string }) {
+  const navigate = useNavigate();
+  return (
+    <div className="border p-4 cursor-pointer" onClick={() => navigate(`/lot/${lot}`)}>
+      <div className="text-lg font-semibold">Lot {lot}</div>
+      <div className="text-sm text-gray-400">Created 2024-04-24</div>
+    </div>
+  );
+}

--- a/src/components/Radar.tsx
+++ b/src/components/Radar.tsx
@@ -1,0 +1,10 @@
+interface Props {
+  lot: string;
+  wafer: string;
+  chip: string;
+}
+export default function Radar({ lot, wafer, chip }: Props) {
+  return (
+    <div className="border p-4">Radar chart placeholder for chip {chip}</div>
+  );
+}

--- a/src/components/WaferThumb.tsx
+++ b/src/components/WaferThumb.tsx
@@ -1,0 +1,7 @@
+export default function WaferThumb({ id, onClick }: { id: string; onClick: () => void }) {
+  return (
+    <div className="border p-2 cursor-pointer" onClick={onClick}>
+      Wafer {id}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/src/pages/ChipDetail.tsx
+++ b/src/pages/ChipDetail.tsx
@@ -1,0 +1,23 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { fetchAiComment } from '../api/comment';
+import { useEffect, useState } from 'react';
+import Radar from '../components/Radar';
+
+export default function ChipDetail() {
+  const { lotId, waferId, chipId } = useParams();
+  const [comment, setComment] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetchAiComment({ lot: lotId!, wafer: waferId!, param: '', device: '' }).then(setComment);
+  }, [lotId, waferId]);
+
+  return (
+    <div className="p-4">
+      <button onClick={() => navigate(-1)} className="mb-4">Back</button>
+      <h1 className="text-2xl font-bold mb-4">Chip {chipId}</h1>
+      <Radar lot={lotId!} wafer={waferId!} chip={chipId!} />
+      <div className="mt-4 p-2 border">{comment}</div>
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { loadCsv, lotStats } from '../utils/wat';
+import LotCard from '../components/LotCard';
+
+export default function Home() {
+  const [lots, setLots] = useState<any[]>([]);
+  useEffect(() => {
+    loadCsv().then(records => {
+      const stats = lotStats(records);
+      setLots(Object.keys(stats));
+    });
+  }, []);
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">SELECT WAFER LOT</h1>
+      <div className="grid gap-4">
+        {lots.map(lot => (
+          <LotCard key={lot} lot={lot} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/WaferDetail.tsx
+++ b/src/pages/WaferDetail.tsx
@@ -1,0 +1,23 @@
+import { useParams, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+import Heatmap from '../components/Heatmap';
+import { fetchAiComment } from '../api/comment';
+
+export default function WaferDetail() {
+  const { lotId, waferId } = useParams();
+  const [comment, setComment] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    fetchAiComment({ lot: lotId!, wafer: waferId!, param: '', device: '' }).then(setComment);
+  }, [lotId, waferId]);
+
+  return (
+    <div className="p-4">
+      <button onClick={() => navigate(-1)} className="mb-4">Back</button>
+      <h1 className="text-2xl font-bold mb-4">Wafer {waferId}</h1>
+      <Heatmap lot={lotId!} wafer={waferId!} onSelectChip={(c) => navigate(`/lot/${lotId}/wafer/${waferId}/chip/${c}`)} />
+      <div className="mt-4 p-2 border">{comment}</div>
+    </div>
+  );
+}

--- a/src/pages/WaferSelect.tsx
+++ b/src/pages/WaferSelect.tsx
@@ -1,0 +1,17 @@
+import { useParams, useNavigate } from 'react-router-dom';
+
+export default function WaferSelect() {
+  const { lotId } = useParams();
+  const navigate = useNavigate();
+  const wafers = Array.from({ length: 4 }, (_, i) => `0${i+1}`); // dummy
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Wafer Selection - Lot {lotId}</h1>
+      <div className="grid grid-cols-2 gap-4">
+        {wafers.map(w => (
+          <div key={w} onClick={() => navigate(`/lot/${lotId}/wafer/${w}`)} className="cursor-pointer border p-4">Wafer {w}</div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/utils/wat.ts
+++ b/src/utils/wat.ts
@@ -1,0 +1,27 @@
+import * as d3 from 'd3';
+
+export interface Record {
+  lot: string;
+  site: string;
+  coord: string;
+  item: string;
+  device: string;
+  parameter: string;
+  specHigh: number | null;
+  specLow: number | null;
+  value: number | null;
+}
+
+export async function loadCsv(): Promise<Record[]> {
+  const data = await d3.csv('/data/WAT_9site_dummy_long_v2.csv');
+  return data as unknown as Record[];
+}
+
+export function lotStats(records: Record[]): { [lot: string]: { total: number; ng: number; marginal: number } } {
+  const stats: any = {};
+  records.forEach(r => {
+    stats[r.lot] = stats[r.lot] || { total: 0, ng: 0, marginal: 0 };
+    stats[r.lot].total++;
+  });
+  return stats;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "types": ["vite/client"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize React + Vite project
- add placeholder components and pages
- include mock WAT CSV and AI comment API
- document how to start the app

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500fa3972c83318a801a8d476567d7